### PR TITLE
Print EmailAddress entities by showing their address.

### DIFF
--- a/lib/ppl/entity/email_address.rb
+++ b/lib/ppl/entity/email_address.rb
@@ -9,5 +9,9 @@ class Ppl::Entity::EmailAddress
     @preferred = false
   end
 
+  def to_s()
+    return @address
+  end
+
 end
 


### PR DESCRIPTION
When printing addresses, the default to_s was being used, which resulted in an unfriendly output such as:

    <#<Ppl::Entity::EmailAddress:0x00000001ffbd28>>

This PR changes this to be something more user friendly, like

    hugo@barrera.io

This is especially relevant when using the scrapper to import addresses, as the previous output was something like:

    Add "Hugo Osvaldo Barrera #<Ppl::Entity::EmailAddress:0x00000001ffbd28>>" to
    your address book [Y/n]?

Which was not at all useful, to say the least.